### PR TITLE
Refactor Generation struct and repository methods

### DIFF
--- a/text2manim-demo-server/cmd/main.go
+++ b/text2manim-demo-server/cmd/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	db := infrastructure.NewDatabase(cfg, log)
 	repo := repository.NewGenerationRepository(db, log)
-	useCase := usecase.NewGenerationUseCase(repo, cfg.RateLimitRequests, cfg.RateLimitInterval, cfg.Text2manimApiEndpoint, cfg.Text2manimApiKey, log)
+	useCase := usecase.NewVideoGenerationUseCase(repo, cfg.RateLimitRequests, cfg.RateLimitInterval, cfg.Text2manimApiEndpoint, cfg.Text2manimApiKey, log)
 	handler := api.NewHandler(useCase, log)
 
 	r := gin.Default()

--- a/text2manim-demo-server/internal/api/handler.go
+++ b/text2manim-demo-server/internal/api/handler.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Handler struct {
-	useCase usecase.GenerationUseCase
+	useCase usecase.VideoGenerationUseCase
 	log     *slog.Logger
 }
 
-func NewHandler(useCase usecase.GenerationUseCase, log *slog.Logger) *Handler {
+func NewHandler(useCase usecase.VideoGenerationUseCase, log *slog.Logger) *Handler {
 	return &Handler{useCase: useCase, log: log}
 }
 
@@ -29,7 +29,7 @@ func (h *Handler) CreateGeneration(c *gin.Context) {
 		return
 	}
 
-	requestID, err := h.useCase.CreateGeneration(request.Email, request.Prompt)
+	requestID, err := h.useCase.RequestVideoGeneration(request.Email, request.Prompt)
 	if err != nil {
 		h.log.Error("Failed to create generation", "error", err, "email", request.Email)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -43,7 +43,7 @@ func (h *Handler) CreateGeneration(c *gin.Context) {
 func (h *Handler) GetGeneration(c *gin.Context) {
 	requestID := c.Param("request_id")
 
-	generation, err := h.useCase.GetGeneration(requestID)
+	generation, err := h.useCase.GetVideoGenerationStatus(requestID)
 	if err != nil {
 		h.log.Error("Failed to get generation", "error", err, "requestID", requestID)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -63,7 +63,7 @@ func (h *Handler) HealthCheck(c *gin.Context) {
 	}
 
 	// 動画生成APIの状態を確認
-	if err := h.useCase.CheckText2ManimApiConnection(); err != nil {
+	if err := h.useCase.CheckText2ManimAPIConnection(); err != nil {
 		h.log.Error("Video API health check failed", "error", err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "unhealthy", "message": "Video API connection failed"})
 		return

--- a/text2manim-demo-server/internal/domain/generation.go
+++ b/text2manim-demo-server/internal/domain/generation.go
@@ -3,14 +3,16 @@ package domain
 import "time"
 
 type Generation struct {
-	ID        uint      `gorm:"primaryKey"`
-	RequestID string    `gorm:"unique;not null"`
-	Email     string    `gorm:"not null"`
-	Prompt    string    `gorm:"not null"`
-	Status    string    `gorm:"not null"`
-	VideoURL  string    `gorm:"default:null"`
-	ScriptURL string    `gorm:"default:null"`
-	CreatedAt time.Time `gorm:"not null"`
+	ID           uint      `gorm:"primaryKey"`
+	RequestID    string    `gorm:"unique;not null"`
+	Email        string    `gorm:"not null"`
+	Prompt       string    `gorm:"not null"`
+	Status       string    `gorm:"not null"`
+	VideoURL     string    `gorm:"default:null"`
+	ScriptURL    string    `gorm:"default:null"`
+	ErrorMessage string    `gorm:"default:null"`
+	CreatedAt    time.Time `gorm:"not null"`
+	UpdatedAt    time.Time `gorm:"not null"`
 }
 
 type GenerationStatus string
@@ -20,3 +22,12 @@ const (
 	StatusCompleted GenerationStatus = "COMPLETED"
 	StatusFailed    GenerationStatus = "FAILED"
 )
+
+type GenerationResponse struct {
+	Status       string `json:"status"`
+	VideoURL     string `json:"video_url"`
+	ScriptURL    string `json:"script_url"`
+	Prompt       string `json:"prompt"`
+	ErrorMessage string `json:"error_message"`
+	UpdatedAt    int64  `json:"updated_at"`
+}

--- a/text2manim-demo-server/internal/repository/generation_repository.go
+++ b/text2manim-demo-server/internal/repository/generation_repository.go
@@ -12,7 +12,7 @@ import (
 type GenerationRepository interface {
 	Create(generation *domain.Generation) error
 	FindByRequestID(requestID string) (*domain.Generation, error)
-	UpdateStatus(requestID string, status domain.GenerationStatus) error
+	Update(requestID string, generation *domain.Generation) error
 	Ping() error
 }
 
@@ -73,23 +73,23 @@ func (r *generationRepository) FindByRequestID(requestID string) (*domain.Genera
 	return &generation, nil
 }
 
-func (r *generationRepository) UpdateStatus(requestID string, status domain.GenerationStatus) error {
+func (r *generationRepository) Update(requestID string, generation *domain.Generation) error {
 	start := time.Now()
-	err := r.db.Model(&domain.Generation{}).Where("request_id = ?", requestID).Update("status", status).Error
+	err := r.db.Model(&domain.Generation{}).Where("request_id = ?", requestID).Updates(generation).Error
 	duration := time.Since(start)
 
 	if err != nil {
 		r.log.Error("Failed to update generation status",
 			"error", err,
 			"requestID", requestID,
-			"newStatus", status,
+			"status", generation.Status,
 			"duration", duration)
 		return err
 	}
 
 	r.log.Info("Generation status updated",
 		"requestID", requestID,
-		"newStatus", status,
+		"status", generation.Status,
 		"duration", duration)
 	return nil
 }

--- a/text2manim-demo-server/internal/usecase/generation_usecase.go
+++ b/text2manim-demo-server/internal/usecase/generation_usecase.go
@@ -16,34 +16,34 @@ import (
 	"gorm.io/gorm"
 )
 
-type GenerationUseCase interface {
-	CreateGeneration(email, prompt string) (string, error)
-	GetGeneration(requestID string) (domain.Generation, error)
+type VideoGenerationUseCase interface {
+	RequestVideoGeneration(email, prompt string) (string, error)
+	GetVideoGenerationStatus(requestID string) (domain.Generation, error)
 	CheckDatabaseConnection() error
-	CheckText2ManimApiConnection() error
+	CheckText2ManimAPIConnection() error
 }
 
-type generationUseCase struct {
-	repo                  repository.GenerationRepository
-	rateLimiter           *ratelimiter.RateLimiter
-	text2ManimApiEndpoint string
-	text2ManimApiKey      string
-	log                   *slog.Logger
+type videoGenerationUseCase struct {
+	repo             repository.GenerationRepository
+	rateLimiter      *ratelimiter.RateLimiter
+	text2ManimAPIURL string
+	text2ManimAPIKey string
+	logger           *slog.Logger
 }
 
-func NewGenerationUseCase(repo repository.GenerationRepository, limit int, interval time.Duration, text2ManimApiEndpoint string, text2ManimApiKey string, log *slog.Logger) GenerationUseCase {
-	return &generationUseCase{
-		repo:                  repo,
-		rateLimiter:           ratelimiter.NewRateLimiter(limit, interval),
-		text2ManimApiEndpoint: text2ManimApiEndpoint,
-		text2ManimApiKey:      text2ManimApiKey, // APIキーを設定
-		log:                   log,
+func NewVideoGenerationUseCase(repo repository.GenerationRepository, limit int, interval time.Duration, text2ManimAPIURL string, text2ManimAPIKey string, logger *slog.Logger) VideoGenerationUseCase {
+	return &videoGenerationUseCase{
+		repo:             repo,
+		rateLimiter:      ratelimiter.NewRateLimiter(limit, interval),
+		text2ManimAPIURL: text2ManimAPIURL,
+		text2ManimAPIKey: text2ManimAPIKey,
+		logger:           logger,
 	}
 }
 
-func (uc *generationUseCase) CreateGeneration(email, prompt string) (string, error) {
+func (uc *videoGenerationUseCase) RequestVideoGeneration(email, prompt string) (string, error) {
 	if !uc.rateLimiter.Allow() {
-		uc.log.Warn("Rate limit exceeded", "email", email)
+		uc.logger.Warn("Rate limit exceeded", "email", email)
 		return "", errors.New("rate limit exceeded")
 	}
 
@@ -56,30 +56,24 @@ func (uc *generationUseCase) CreateGeneration(email, prompt string) (string, err
 		CreatedAt: time.Now(),
 	}
 
-	// データベースに保存
-	err := uc.repo.Create(generation)
-	if err != nil {
-		uc.log.Error("Failed to create generation in database", "error", err, "requestID", requestID)
-		return "", fmt.Errorf("failed to create generation: %w", err)
+	if err := uc.repo.Create(generation); err != nil {
+		uc.logger.Error("Failed to create generation record", "error", err, "requestID", requestID)
+		return "", fmt.Errorf("failed to create generation record: %w", err)
 	}
 
-	// APIを呼び出し
-	err = uc.callVideoGenerationApi(requestID, prompt)
-	if err != nil {
-		uc.log.Error("Failed to call video generation API", "error", err, "requestID", requestID)
-		// APIの呼び出しに失敗した場合、ステータスを更新
+	if err := uc.initiateVideoGeneration(requestID, prompt); err != nil {
+		uc.logger.Error("Failed to initiate video generation", "error", err, "requestID", requestID)
 		generation.Status = string(domain.StatusFailed)
-		updateErr := uc.repo.Update(requestID, generation)
-		if updateErr != nil {
-			uc.log.Error("Failed to update generation status", "error", updateErr, "requestID", requestID)
+		if updateErr := uc.repo.Update(requestID, generation); updateErr != nil {
+			uc.logger.Error("Failed to update generation status", "error", updateErr, "requestID", requestID)
 		}
-		return requestID, fmt.Errorf("failed to start video generation: %w", err)
+		return requestID, fmt.Errorf("failed to initiate video generation: %w", err)
 	}
 
 	return requestID, nil
 }
 
-func (uc *generationUseCase) callVideoGenerationApi(requestID, prompt string) error {
+func (uc *videoGenerationUseCase) initiateVideoGeneration(requestID, prompt string) error {
 	payload := map[string]string{
 		"request_id": requestID,
 		"prompt":     prompt,
@@ -89,14 +83,14 @@ func (uc *generationUseCase) callVideoGenerationApi(requestID, prompt string) er
 		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/generations", uc.text2ManimApiEndpoint)
+	url := fmt.Sprintf("%s/v1/generations", uc.text2ManimAPIURL)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-Key", uc.text2ManimApiKey) // APIキーをヘッダーに追加
+	req.Header.Set("X-Api-Key", uc.text2ManimAPIKey)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -112,48 +106,45 @@ func (uc *generationUseCase) callVideoGenerationApi(requestID, prompt string) er
 	return nil
 }
 
-func (uc *generationUseCase) GetGeneration(requestID string) (domain.Generation, error) {
+func (uc *videoGenerationUseCase) GetVideoGenerationStatus(requestID string) (domain.Generation, error) {
 	generation, err := uc.repo.FindByRequestID(requestID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			uc.log.Info("Generation not found", "requestID", requestID)
+			uc.logger.Info("Generation not found", "requestID", requestID)
 			return domain.Generation{}, fmt.Errorf("generation not found")
 		}
-		uc.log.Error("Failed to get generation status", "error", err, "requestID", requestID)
+		uc.logger.Error("Failed to get generation status", "error", err, "requestID", requestID)
 		return domain.Generation{}, fmt.Errorf("failed to get generation status: %w", err)
 	}
 
-	// APIから最新の状態を取得
-	resp, err := uc.checkVideoGenerationStatus(requestID)
+	apiStatus, err := uc.fetchVideoGenerationStatus(requestID)
 	if err != nil {
-		uc.log.Error("Failed to check video generation status", "error", err, "requestID", requestID)
-		return *generation, nil // エラーが発生しても現在の状態を返す
+		uc.logger.Error("Failed to fetch video generation status", "error", err, "requestID", requestID)
+		return *generation, nil
 	}
 
-	// データベースの状態を更新
-	generation.Status = string(resp.Status)
-	generation.VideoURL = resp.VideoURL
-	generation.ScriptURL = resp.ScriptURL
-	generation.ErrorMessage = resp.ErrorMessage
-	generation.UpdatedAt = time.Unix(resp.UpdatedAt, 0)
+	generation.Status = string(apiStatus.Status)
+	generation.VideoURL = apiStatus.VideoURL
+	generation.ScriptURL = apiStatus.ScriptURL
+	generation.ErrorMessage = apiStatus.ErrorMessage
+	generation.UpdatedAt = time.Unix(apiStatus.UpdatedAt, 0)
 
-	err = uc.repo.Update(requestID, generation)
-	if err != nil {
-		uc.log.Error("Failed to update generation in database", "error", err, "requestID", requestID)
+	if err := uc.repo.Update(requestID, generation); err != nil {
+		uc.logger.Error("Failed to update generation record", "error", err, "requestID", requestID)
 	}
 
-	uc.log.Info("Generation status retrieved and updated", "requestID", requestID, "generation", generation)
+	uc.logger.Info("Generation status updated", "requestID", requestID, "generation", generation)
 	return *generation, nil
 }
 
-func (uc *generationUseCase) checkVideoGenerationStatus(requestID string) (*domain.GenerationResponse, error) {
-	url := fmt.Sprintf("%s/v1/generations/%s", uc.text2ManimApiEndpoint, requestID)
+func (uc *videoGenerationUseCase) fetchVideoGenerationStatus(requestID string) (*domain.GenerationResponse, error) {
+	url := fmt.Sprintf("%s/v1/generations/%s", uc.text2ManimAPIURL, requestID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Api-Key", uc.text2ManimApiKey)
+	req.Header.Set("X-Api-Key", uc.text2ManimAPIKey)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -176,18 +167,18 @@ func (uc *generationUseCase) checkVideoGenerationStatus(requestID string) (*doma
 	return &result.GenerationStatus, nil
 }
 
-func (uc *generationUseCase) CheckDatabaseConnection() error {
+func (uc *videoGenerationUseCase) CheckDatabaseConnection() error {
 	return uc.repo.Ping()
 }
 
-func (uc *generationUseCase) CheckText2ManimApiConnection() error {
-	url := fmt.Sprintf("%s/v1/health", uc.text2ManimApiEndpoint)
+func (uc *videoGenerationUseCase) CheckText2ManimAPIConnection() error {
+	url := fmt.Sprintf("%s/v1/health", uc.text2ManimAPIURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("X-Api-Key", uc.text2ManimApiKey) // APIキーをヘッダーに追加
+	req.Header.Set("X-Api-Key", uc.text2ManimAPIKey)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
This pull request refactors the Generation struct and repository methods. It updates the Generation struct to include new fields such as ErrorMessage and UpdatedAt. The UpdateStatus method in the GenerationRepository interface is renamed to Update and now takes a Generation object as a parameter instead of just the status. The Update method in the generationRepository implementation is also updated to use the Updates function instead of Update. The Handler struct and NewHandler function are updated to use the VideoGenerationUseCase instead of the GenerationUseCase. The CreateGeneration and GetGeneration methods in the Handler struct are updated to use the RequestVideoGeneration and GetVideoGenerationStatus methods in the VideoGenerationUseCase. Additionally, the HealthCheck method in the Handler struct is updated to use the CheckText2ManimAPIConnection method instead of CheckText2ManimApiConnection.